### PR TITLE
Cloud Runをapplyの度に強制replaceする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
           terraform plan
 
   apply:
-    # if: ${{ github.ref == 'refs/heads/main' }}
-    # needs: plan
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: plan
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
           terraform plan
 
   apply:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    needs: plan
+    # if: ${{ github.ref == 'refs/heads/main' }}
+    # needs: plan
     runs-on: ubuntu-latest
 
     steps:
@@ -93,4 +93,4 @@ jobs:
           export TF_VAR_service_name=${{ secrets.GCP_SERVICE_NAME }}
           export TF_VAR_image_name=${{ secrets.GCP_IMAGE_NAME }}
           cd terraform
-          terraform apply --auto-approve
+          terraform apply --auto-approve -replace="google_cloud_run_v2_service.default"


### PR DESCRIPTION
backendサーバーがメモリいっぱいになって動作不能になったときの最終手段
このworkflowを手動で回すことでbackendのcloud runを強引にリセットする